### PR TITLE
mark even and odd comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ide files
+.idea

--- a/app/views/journals/_mark_even_odd.js.erb
+++ b/app/views/journals/_mark_even_odd.js.erb
@@ -1,0 +1,6 @@
+$('#history .journal').removeClass('odd').removeClass('even');
+
+// Note that, confusingly, jQuery's filter pseudos are 0-indexed while CSS :nth-child() is 1-indexed
+$('#history .journal:visible:even').addClass('odd');
+$('#history .journal:visible:odd').addClass('even');
+

--- a/assets/javascripts/issue-history-tabs.js
+++ b/assets/javascripts/issue-history-tabs.js
@@ -5,14 +5,32 @@ $(document).ready(function(){
   function show_only_comments() {
     $('a#tab-history-comments').addClass('selected');
     $('a#tab-history-all').removeClass('selected');
-    $('.journal.has-notes.has-details .details, .journal.has-details').hide();
-    $('.journal.has-notes').show();
+
+    $('#history .journal.has-notes.has-details .details, ' +
+      '#history .journal.has-details').addClass('hidden');
+    $('#history .journal.has-notes').removeClass('hidden');
+
+    mark_even_odd();
   }
 
   function show_history() {
     $('a#tab-history-comments').removeClass('selected');
     $('a#tab-history-all').addClass('selected');
-    $('.journal.has-notes.has-details .details,.journal.has-notes.has-details, .journal.has-details, .journal').show();
+
+    $('#history .journal.has-notes.has-details .details,' +
+      '#history .journal.has-notes.has-details, ' +
+      '#history .journal.has-details, ' +
+      '#history .journal').removeClass('hidden');
+
+    mark_even_odd();
+  }
+
+  function mark_even_odd() {
+    $('#history .journal').removeClass('odd').removeClass('even');
+
+    // Note that, confusingly, jQuery's filter pseudos are 0-indexed while CSS :nth-child() is 1-indexed
+    $('#history .journal:visible:even').addClass('odd');
+    $('#history .journal:visible:odd').addClass('even');
   }
 
   $('a#tab-history-all').bind("click",function(e){

--- a/assets/stylesheets/issue_history_tabs.css
+++ b/assets/stylesheets/issue_history_tabs.css
@@ -2,3 +2,7 @@
 {
   display: none;
 }
+
+#history .hidden {
+  display: none;
+}

--- a/init.rb
+++ b/init.rb
@@ -1,10 +1,11 @@
 require 'redmine'
 require 'redmine_issue_history_listener.rb'
+require 'redmine_issue_history_x/hooks/view_journals_update_js_bottom_hook'
 
 Redmine::Plugin.register :redmine_issue_history do
   name 'redmine_issue_history'
   author 'Systango'
   description 'This plugin provide history of issue in tabs representation'
-  version '1.0.0'
+  version '1.1.0'
   requires_redmine :version_or_higher => '2.2.4'
 end

--- a/lib/redmine_issue_history_x/hooks/view_journals_update_js_bottom_hook.rb
+++ b/lib/redmine_issue_history_x/hooks/view_journals_update_js_bottom_hook.rb
@@ -1,0 +1,8 @@
+# RedmineIssueHistoryX because the name RedmineIssueHistory is used by lib/redmine_issue_history_listener.rb
+module RedmineIssueHistoryX
+  module Hooks
+    class ViewJournalsUpdateJsBottomHook < Redmine::Hook::ViewListener
+      render_on(:view_journals_update_js_bottom, partial: 'journals/mark_even_odd', layout: false)
+    end
+  end
+end


### PR DESCRIPTION
mark even and odd comments, but only the visible ones.

now comments are ready to be [customized through css](https://github.com/martin-denizet/redmine_custom_css) like
```
#history .journal.even {
  background-color: red;
}

#history .journal.odd {
  background-color: yellow;
}
```

[a pure css solution is not possible](stackoverflow.com/q/26057925).